### PR TITLE
Played around with drag and slider, ended up implementing slider_int

### DIFF
--- a/src/bindings_imgui.cpp
+++ b/src/bindings_imgui.cpp
@@ -411,6 +411,19 @@ void loadImguiPythonBindings(pybind11::module& m, ImViz& viz) {
     py::arg("min") = 0.0,
     py::arg("max") = 1.0);
 
+    m.def("slider_int", [&](const std::string title, int& value, const int min, const int max) {
+        
+        bool mod = ImGui::SliderInt(
+                title.c_str(), &value, min, max);
+        viz.setMod(mod);
+
+        return value;
+    }, 
+    py::arg("label"),
+    py::arg("value"),
+    py::arg("min") = 0,
+    py::arg("max") = 1);
+
     m.def("drag", [&](std::string title, int& value, float speed, int min, int max) {
         
         bool mod = ImGui::DragInt(title.c_str(), &value, speed, min, max);


### PR DESCRIPTION
Small contribution of slider_int as the others did not fit my usecase.
Should I also add sample code for it?

     self.data = [1,2,3]
     self.index = viz.slider_int("choose index", self.index, 0, len(self.data) - 1)