### PR TITLE
Fix compilation and autogui on Windows, MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 .cache
 *.egg-info
 *.so
+*.dll
+*.pyd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,25 +15,6 @@ else(OPENGL_FOUND)
     message(FATAL_ERROR "${ColourBoldRed}OpenGL missing.${ColourReset}")
 endif()
 
-# ---[ Check for GLEW (mandatory) ]---
-
-find_package(GLEW QUIET)
-if(GLEW_FOUND)
-    message(STATUS "Found GLEW: " ${GLEW_LIBRARIES})
-    message(STATUS "            " ${GLEW_INCLUDE_DIR})
-else(GLEW_FOUND)
-    message(FATAL_ERROR "${ColourBoldRed}GLEW missing.${ColourReset}")
-endif()
-
-# ---[ Check for GLFW3 (mandatory) ]---
-
-find_package(glfw3 QUIET)
-if(glfw3_FOUND)
-    message(STATUS "Found GLFW3")
-else(glfw3_FOUND)
-    message(FATAL_ERROR "${ColourBoldRed}GLFW3 missing.${ColourReset}")
-endif()
-
 # ---[ Update submodules ]---
 # From: https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html
 
@@ -73,7 +54,19 @@ FetchContent_Declare(
 FetchContent_Declare(
     pybind
     GIT_REPOSITORY "https://github.com/pybind/pybind11"
-    GIT_TAG "59a2ac2745d8a57ac94c6accced73620d59fb844"
+    GIT_TAG "v2.10.0"
+)
+
+FetchContent_Declare(
+    glew
+    GIT_REPOSITORY "https://github.com/Perlmint/glew-cmake"
+    GIT_TAG "glew-cmake-2.2.0"
+)
+
+FetchContent_Declare(
+    glfw
+    GIT_REPOSITORY "https://github.com/glfw/glfw"
+    GIT_TAG "3.3-stable"
 )
 
 message(STATUS "Loading implot ...")
@@ -81,6 +74,13 @@ FetchContent_MakeAvailable(implot)
 
 message(STATUS "Loading pybind ...")
 FetchContent_MakeAvailable(pybind)
+
+message(STATUS "Loading glew ...")
+set(glew-cmake_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(glew)
+
+message(STATUS "Loading glfw ...")
+FetchContent_MakeAvailable(glfw)
 
 message(STATUS "")
 message(STATUS "All dependencies loaded.")
@@ -171,7 +171,6 @@ ELSE()
                             -Wpedantic
                             -Wunreachable-code
                             -std=c++17)
-    
     target_link_libraries(${PY_TARGET_NAME} PUBLIC
                             ${OPENGL_LIBRARIES}
                             libglew_static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,29 +127,59 @@ set(HEADER_FILES
 
 pybind11_add_module(${PY_TARGET_NAME} MODULE ${SOURCE_FILES})
 
-target_link_libraries(${PY_TARGET_NAME} PUBLIC
-                      ${OPENGL_LIBRARIES}
-                      ${GLEW_LIBRARIES}
-                      stdc++fs
-                      pybind11::module
-                      pybind11::embed
-                      glfw)
-
 target_include_directories(${PY_TARGET_NAME} SYSTEM PUBLIC
                            extern/imgui/
                            ${implot_SOURCE_DIR})
 
 target_include_directories(${PY_TARGET_NAME} PUBLIC src/)
 
-target_compile_options(${PY_TARGET_NAME} PUBLIC
-                        -DIMGUI_USER_CONFIG="im_user_config.h"
-                        -g
-                        -O3
-                        -Wall
-                        -Wextra
-                        -Wpedantic
-                        -Wunreachable-code
-                        -std=c++17)
+IF (WIN32)
+    target_compile_options(${PY_TARGET_NAME} PUBLIC
+                            -DIMGUI_USER_CONFIG="im_user_config.h"
+                            -Zi   # -g
+                            -O2   # msvc has no -O3
+                            # -Wall
+                            -std:c++17)  # note colon!
+    
+    target_link_libraries(${PY_TARGET_NAME} PUBLIC
+                            ${OPENGL_LIBRARIES}
+                            libglew_static
+                            # stdc++fs  # not needed with msvc
+                            pybind11::module
+                            pybind11::embed
+                            glfw)
+ELSEIF(APPLE)
+    target_compile_options(${PY_TARGET_NAME} PUBLIC
+                            -DIMGUI_USER_CONFIG="im_user_config.h"
+                            -g
+                            -O3
+                            -std=c++17)
+
+    target_link_libraries(${PY_TARGET_NAME} PUBLIC
+                            ${OPENGL_LIBRARIES}
+                            libglew_static
+                            pybind11::module
+                            #pybind11::embed  # issues with conda + ARM (Apple M1), see https://github.com/pybind/pybind11/issues/3081
+                            glfw)
+ELSE()
+    target_compile_options(${PY_TARGET_NAME} PUBLIC
+                            -DIMGUI_USER_CONFIG="im_user_config.h"
+                            -g
+                            -O3
+                            -Wall
+                            -Wextra
+                            -Wpedantic
+                            -Wunreachable-code
+                            -std=c++17)
+    
+    target_link_libraries(${PY_TARGET_NAME} PUBLIC
+                            ${OPENGL_LIBRARIES}
+                            libglew_static
+                            stdc++fs
+                            pybind11::module
+                            pybind11::embed
+                            glfw)
+ENDIF()
 
 # Exports compile commands to .json file for vim YouCompleteMe support.
 

--- a/imviz/dev.py
+++ b/imviz/dev.py
@@ -3,6 +3,8 @@ import sys
 import inspect
 import datetime
 import traceback
+import platform
+from pydoc import locate
 
 import imviz as viz
 
@@ -17,7 +19,12 @@ def launch(cls, func_name):
     os.environ["PYTHONPATH"] = ":".join(
             sys.path + [os.path.dirname(file_path)])
 
-    os.execlpe("python3",
+    if platform.system() == 'Windows':
+        # execlpe has different semantics on Windows
+        cls = locate(cls_name)
+        loop(cls, func_name)
+    else:
+        os.execlpe(sys.executable,
                "python3",
                "-m",
                "imviz.dev_main",

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -262,7 +262,7 @@ PYBIND11_MODULE(cppimviz, m) {
 
             ImGui::TableHeadersRow();
 
-            for (ssize_t r = 0; r < index.size(); ++r) {
+            for (size_t r = 0; r < index.size(); ++r) {
                 ImGui::TableNextRow();
 
                 py::object rowIndex = indexGetFunc(r);

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -39,6 +39,7 @@ PYBIND11_MODULE(cppimviz, m) {
      * Input module bindings
      */
 
+    viz.init();
     input::loadPythonBindings(m);
 
     loadImguiPythonBindings(m, viz);

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -24,8 +24,7 @@
  * This allows us to handle imgui assertions via exceptions on the python side.
  */
 void checkAssertion(bool expr, const char* exprStr) {
-
-    if (not expr) { 
+    if (!expr) { 
         throw std::runtime_error(exprStr);
     }
 }

--- a/src/bindings_imgui.cpp
+++ b/src/bindings_imgui.cpp
@@ -2,6 +2,8 @@
 
 #include "binding_helpers.hpp"
 #include "imviz.hpp"
+
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <imgui.h>
 #include <pybind11/pytypes.h>
@@ -1247,7 +1249,7 @@ void loadImguiPythonBindings(pybind11::module& m, ImViz& viz) {
 
             ImVec4 fillCol = interpretColor(fillColor);
 
-            if (fillCol.w != -1 and lineWidth > 0.0) {
+            if (fillCol.w != -1 && lineWidth > 0.0) {
 
                 ImU32 col = ImGui::GetColorU32(fillCol);
                 
@@ -1457,7 +1459,7 @@ void loadImguiPythonBindings(pybind11::module& m, ImViz& viz) {
 
             ImVec4 lineCol = interpretColor(lineColor);
 
-            if (lineCol.w != -1 and lineWidth > 0) {
+            if (lineCol.w != -1 && lineWidth > 0) {
 
                 ImDrawIdx idx = (ImDrawIdx)dl._VtxCurrentIdx;
                 ImU32 col = ImGui::GetColorU32(lineCol);

--- a/src/bindings_implot.cpp
+++ b/src/bindings_implot.cpp
@@ -3,6 +3,8 @@
 #include "binding_helpers.hpp"
 #include "imviz.hpp"
 
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include "implot_internal.h"
 #include <imgui.h>
 #include <implot.h>
@@ -794,7 +796,7 @@ void loadImplotPythonBindings(pybind11::module& m, ImViz& viz) {
         ImPlotContext& gp = *GImPlot;
         ImGuiIO& IO = ImGui::GetIO();
         return (ImPlot::GetCurrentPlot()->Selecting
-                and IO.MouseReleased[gp.InputMap.Select]);
+                && IO.MouseReleased[gp.InputMap.Select]);
     });
 
     m.def("cancel_plot_selection", ImPlot::CancelPlotSelection);

--- a/src/file_dialog.cpp
+++ b/src/file_dialog.cpp
@@ -25,10 +25,11 @@ namespace ImGui {
                     || fs::path(selectedPath).filename().empty()) {
                 selectedPath = fs::path(selectedPath)
                     .parent_path()
-                    .parent_path();
+                    .parent_path()
+                    .string();
             } else {
                 selectedPath = fs::path(selectedPath)
-                    .parent_path();
+                    .parent_path().string();
             }
         }
 
@@ -43,7 +44,7 @@ namespace ImGui {
 
         if (fs::exists(listPath)) {
             for (fs::directory_entry e : fs::directory_iterator(listPath)) {
-                if (std::string(e.path().filename()).at(0) != '.') {
+                if (e.path().filename().string().at(0) != '.') {
                     entries.push_back(e);
                 }
             }
@@ -69,8 +70,8 @@ namespace ImGui {
 
         for (fs::directory_entry e : entries) {
 
-            std::string displayName = e.path().stem();
-            displayName += e.path().extension();
+            std::string displayName = e.path().stem().string();
+            displayName += e.path().extension().string();
 
             if (fs::is_directory(e)) {
                 displayName += "/";
@@ -78,9 +79,9 @@ namespace ImGui {
 
             if (ImGui::Selectable(
                         displayName.c_str(),
-                        selectedPath == e.path())) {
+                        selectedPath == e.path().string())) {
 
-                selectedPath = e.path();
+                selectedPath = e.path().string();
             }
         }
 

--- a/src/imviz.cpp
+++ b/src/imviz.cpp
@@ -24,6 +24,12 @@ ImViz::ImViz () {
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     glfwWindowHint(GLFW_FOCUSED, GLFW_FALSE);
 
+    // Required on MacOS
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+
     window = glfwCreateWindow(
             800,
             600,

--- a/src/imviz.cpp
+++ b/src/imviz.cpp
@@ -12,12 +12,22 @@
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
 
-ImViz::ImViz () {
+void error_callback(int error, const char* description) {
+    fprintf(stderr, "GLFW error %d - %s\n", error, description);
+}
+
+// Doing this in the constructor directly breaks on Windows
+void ImViz::init() {
+    if (this->initialized) {
+        return;
+    }
 
     if (!glfwInit()) {
         std::cout << "Could not initialize GLFW!" << std::endl;
         std::exit(-1);
     }
+
+    glfwSetErrorCallback(error_callback);
 
     glfwWindowHint(GLFW_SAMPLES, 4);
     glfwWindowHint(GLFW_FOCUS_ON_SHOW, GLFW_FALSE);
@@ -37,6 +47,11 @@ ImViz::ImViz () {
             nullptr,
             nullptr);
 
+    if (!window) {
+        printf("Window creation failed!\n");
+        exit(1);
+    }
+
     glfwMakeContextCurrent(window);
 
     glewExperimental = true;
@@ -50,6 +65,8 @@ ImViz::ImViz () {
     setupImLibs();
 
     prepareUpdate();
+
+    this->initialized = true;
 }
 
 void ImViz::setupImLibs() {

--- a/src/imviz.hpp
+++ b/src/imviz.hpp
@@ -21,6 +21,7 @@ struct ImViz {
 
     bool currentWindowOpen = false;
     bool figurePlotOpen = false;
+    bool initialized = false;
 
     bool mod = false;
     std::vector<bool> mod_any = {false};
@@ -33,8 +34,9 @@ struct ImViz {
     // initially update for two whole seconds (assuming vsync)
     int powerSaveFrameCounter = 120;
 
-    ImViz();
+    ImViz() = default;
 
+    void init();
     void prepareUpdate();
     void setupImLibs();
     void doUpdate(bool useVsync);

--- a/src/load_image.cpp
+++ b/src/load_image.cpp
@@ -7,7 +7,7 @@
  */
 void checkStbImageAssertion(bool expr, const char* exprStr) {
 
-    if (not expr) { 
+    if (!expr) { 
         throw std::runtime_error(exprStr);
     }
 }


### PR DESCRIPTION
Great work on the library!

Below are commits needed to compile and run imviz on Windows (11) and MacOS (using Apple M1).
The biggest changes:
* Change boolean operators from 'and', 'or' to &&, ||
* Be more explicit about fs::path <=> std::string conversions
* Move ImViz init from constructor to init function (segfaults otherwise on Windows)
* Don't use execlpe on Windows (not sure why this was originally needed?)

Let me know what you think!
-Erik