### PR TITLE
Feat dockspace size

### DIFF
--- a/src/bindings_imgui.cpp
+++ b/src/bindings_imgui.cpp
@@ -957,6 +957,12 @@ void loadImguiPythonBindings(pybind11::module& m, ImViz& viz) {
     py::arg("window_name"),
     py::arg("node_id"));
 
+    m.def("dock_builder_set_node_size", [](ImGuiID nodeId, ImVec2 size) {
+              ImGui::DockBuilderSetNodeSize(nodeId, size);
+          },
+    py::arg("node_id"),
+    py::arg("size"));
+
     m.def("dock_builder_remove_node", ImGui::DockBuilderRemoveNode);
     m.def("dock_builder_remove_node_child_nodes", ImGui::DockBuilderRemoveNodeChildNodes);
     m.def("dock_builder_finish", ImGui::DockBuilderFinish);


### PR DESCRIPTION
On the docker branch. The main dockspace can be split into nodes. Windows can be assigned to these nodes to code the layout of the window on startup.
This is done by ``dock_builder_split_node`` and ``dock_builder_dock_window``.
However, the main dock space has size 0 at the beginning. Hence, it can't be split.
Therefore, ``ImGui::DockBuilderSetNodeSize`` was python-binded to set the size prior to the split.

Now, the layout can be preset like in the following (must be executed only once at startup):
```
dockspace_id = viz.get_main_dockspace_id()
viz.dock_builder_remove_node(dockspace_id)
viz.dock_builder_add_node(dockspace_id)
viz.dock_builder_set_node_size(dockspace_id, viz.get_window_size())

left, middle = viz.dock_builder_split_node(dockspace_id, viz.Dir.LEFT, 0.2)
left, left_bottom = viz.dock_builder_split_node(left, viz.Dir.UP, 0.7)
middle, right = viz.dock_builder_split_node(middle, viz.Dir.LEFT, 0.8)
middle, middle_bottom = viz.dock_builder_split_node(middle, viz.Dir.UP, 0.7)

viz.dock_builder_dock_window("debug", left)
viz.dock_builder_dock_window("map", middle)
viz.dock_builder_dock_window("map_details", middle_bottom)
viz.dock_builder_dock_window("params", right)
viz.dock_builder_dock_window("debug_details", left_bottom)

viz.dock_builder_finish(dockspace_id)
```