### PR TITLE
autogui: support __dir__() in dict-like objects

### DIFF
--- a/imviz/autogui.py
+++ b/imviz/autogui.py
@@ -267,6 +267,8 @@ class AutoguiContext:
             return obj
         elif hasattr(obj, "__dir__"):
             attr_dict = {n: getattr(obj, n) for n in obj.__dir__()}
+            attr_dict = {n: attr for n, attr in attr_dict.items()
+                         if not callable(attr)}
         else:
             if len(name) == 0:
                 viz.text(f"{name}: " + "???")

--- a/imviz/autogui.py
+++ b/imviz/autogui.py
@@ -265,6 +265,8 @@ class AutoguiContext:
                 viz.tree_pop()
 
             return obj
+        elif hasattr(obj, "__dir__"):
+            attr_dict = {n: getattr(obj, n) for n in obj.__dir__()}
         else:
             if len(name) == 0:
                 viz.text(f"{name}: " + "???")

--- a/imviz/autogui.py
+++ b/imviz/autogui.py
@@ -270,7 +270,7 @@ class AutoguiContext:
         else:
             if len(name) == 0:
                 viz.text(f"{name}: " + "???")
-            if tree_open:
+            if len(name) > 0 and tree_open:
                 viz.tree_pop()
             return obj
 


### PR DESCRIPTION
It's a suggestion for the awesome `autogui()` again. ^^
For dict-like objects with dynamic attributes, something like the suggested patch would be nice. This re-adds support for the current [structstore](https://github.com/mertemba/structstore) release (see [this commit](https://github.com/mertemba/structstore/commit/c30a181c8674d23735a27689d5b74d3b20154578)).

The second commit fixes a small bug that I introduced in #16.